### PR TITLE
fix #5 Compiler warning: “initializer-string for array of ‘char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute”

### DIFF
--- a/src/socketio.c
+++ b/src/socketio.c
@@ -592,7 +592,7 @@ void sendUUID(uint16_t seed)
 }
 void sendUUIDString(uint16_t seed)
 {
-  static char const hexdigits_lower[16] = "0123456789abcdef";
+  static char const hexdigits_lower[] = "0123456789abcdef";
   int i;
   char stmp[38];
   for (i = 0; i < 36; i++)


### PR DESCRIPTION
There was a warning error because the array exactly has space for 16 actual characters 
`
static char const hexdigits_lower[16] = "0123456789abcdef";
`
But every string in C automatically adds a hidden \0 at the end, so that means the array has to be 17 bytes long. 
So I just let the compiler infer the size instead of increasing one byte.