### PR TITLE
Non-blocking send queue on EAGAIN

### DIFF
--- a/include/UCraft/player.h
+++ b/include/UCraft/player.h
@@ -11,6 +11,16 @@
 #include "game.h"
 typedef struct gamePlayerData_t gamePlayerData_t;
 typedef struct player_t player_t;
+typedef struct out_packet_t out_packet_t;
+
+struct out_packet_t
+{
+  uint8_t *data;
+  size_t len;
+  size_t sent;
+  out_packet_t *next;
+};
+
 struct player_t
 {
   // General
@@ -69,9 +79,8 @@ struct player_t
   uint8_t swing_arm_event : 1;
   uint8_t entity_action_event : 1;
   // Packet
-  uint8_t packet_dispatch_event : 1;
-  size_t packet_len, packet_sent, packet_timeout;
-  uint8_t *packet;
+  out_packet_t *out_head;
+  out_packet_t *out_tail;
   // Chunk
   int32_t chunk_x, chunk_z, chunk_px, chunk_pz;
   // Player skin

--- a/include/UCraft/socketio.h
+++ b/include/UCraft/socketio.h
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
 
 struct readPacketVars_t
 {
@@ -67,10 +66,11 @@ void sendclearGlobalBuffer();
 void sendGlobalBuffer(player_t *player);
 
 // writing utils, one player context only.
-size_t sendData(uint8_t *data, size_t packetsize);
+size_t sendData(uint8_t *data, size_t packetsize, int *blocked);
 void sendStartPlayer(player_t *player);
 void sendMainByte(uint8_t byte);
 void sendDispatch();
+void sendFlush(player_t *player);
 uint8_t sendAllowed();
 void sendStart();
 void sendByte(uint8_t b);

--- a/include/UCraft/wrapper_unix.h
+++ b/include/UCraft/wrapper_unix.h
@@ -14,6 +14,7 @@
 #include <signal.h>
 #include <netdb.h>
 #include <fcntl.h>
+#include <errno.h>
 // Misc functions
 static inline void U_wrapperStart()
 {

--- a/include/UCraft/wrapper_win.h
+++ b/include/UCraft/wrapper_win.h
@@ -6,6 +6,8 @@
 #include <string.h>
 #include <winsock2.h>
 #include <stdint.h>
+#include <errno.h>
+
 
 // ssize_t is not defined in windows
 #if SIZE_MAX == UINT_MAX

--- a/src/UCraft.c
+++ b/src/UCraft.c
@@ -384,42 +384,8 @@ static void s2cHandler()
                 }
             }
         }
-        if (currentPlayer->packet_dispatch_event)
-        {
-            if (currentPlayer->packet_timeout > SEND_PACKET_TIMEOUT)
-            {
-                currentPlayer->remove_player_event = 1;
-            }
-            else
-            {
-                size_t remaining = currentPlayer->packet_len - currentPlayer->packet_sent;
-                if (remaining == 0)
-                {
-                    if (currentPlayer->packet == NULL)
-                    {
-                        printl(LOG_ERROR, "WTF, idk why this is null\n");
-                        currentPlayer->remove_player_event = 1;
-                        return;
-                    }
-                    U_free(currentPlayer->packet);
-                    currentPlayer->packet_len = 0;
-                    currentPlayer->packet_sent = 0;
-                    currentPlayer->packet = NULL;
-                    currentPlayer->packet_dispatch_event = 0;
-                }
-                else
-                {
-                    size_t totalSent = sendData(&currentPlayer->packet[currentPlayer->packet_sent], remaining);
-                    currentPlayer->packet_sent += totalSent;
-                }
-            }
-            currentPlayer->packet_timeout++;
-        }
-        else
-        {
-            currentPlayer->packet_timeout = 0;
-            sendDispatch();
-        }
+        sendDispatch();
+        sendFlush(currentPlayer);
         currentPlayer->global_buffer_start_index = 0;
         currentPlayer->global_buffer_end_index = 0;
     }

--- a/src/player.c
+++ b/src/player.c
@@ -175,10 +175,14 @@ uint8_t playerRemove(player_t *player)
 #endif /*ONLINE_MODE_AUTH*/
   U_shutdown(player->fd, SHUT_RDWR);
   U_close(player->fd);
-  if (player->packet)
+  while (player->out_head)
   {
-    U_free(player->packet);
+    out_packet_t *pkt = player->out_head;
+    player->out_head = pkt->next;
+    U_free(pkt->data);
+    U_free(pkt);
   }
+  player->out_tail = NULL;
   FD_CLR(player->fd, &masterset);
   if (player->active)
   {

--- a/src/socketio.c
+++ b/src/socketio.c
@@ -244,10 +244,14 @@ void sendGlobalBuffer(player_t *player)
     sendMainByte(sendPacketVars.globalbuffer[i]);
   }
 }
-size_t sendData(uint8_t *data, size_t buffersize)
+size_t sendData(uint8_t *data, size_t buffersize, int *blocked)
 {
   int sock = sendPacketVars.player->fd;
   size_t totalSent = 0;
+  if (blocked != NULL)
+  {
+    *blocked = 0;
+  }
   // split the packet in fragments
   while (totalSent < buffersize)
   {
@@ -257,30 +261,22 @@ size_t sendData(uint8_t *data, size_t buffersize)
 
     if (r < 0)
     {
-      // the issue with EAGAIN is that if we loop over it again with no delay, it will not work so for now just simply dispatch the packet later
-      if (errno == EAGAIN || errno == 0)
+      if (errno == EAGAIN || errno == EWOULDBLOCK)
       {
-        if (sendPacketVars.player->packet)
+        if (blocked != NULL)
         {
-          printl(LOG_WARN, "Packet already exists! try again later\n");
-          return totalSent;
+          *blocked = 1;
         }
-        // allocate the packet
-        sendPacketVars.player->packet = U_malloc(remaining);
-        if (sendPacketVars.player->packet == NULL)
-        {
-          printl(LOG_ERROR, "Memory allocation failed alt packet!\n");
-          sendPacketVars.player->remove_player_event = 1;
-          return totalSent;
-        }
-        // copy the packet
-        sendPacketVars.player->packet_len = remaining;
-        memcpy(sendPacketVars.player->packet, (char *)data + totalSent, remaining);
-        sendPacketVars.player->packet_dispatch_event = 1;
         return totalSent;
       }
       printl(LOG_ERROR, "could not send (%d) code %ld (%p %ld)\n", sock, r, data, totalSent);
       printl(LOG_ERROR, "errno: %s\n", strerror(errno));
+      sendPacketVars.player->remove_player_event = 1;
+      return totalSent;
+    }
+    if (r == 0)
+    {
+      printl(LOG_ERROR, "could not send (%d) code %ld (%p %ld)\n", sock, r, data, totalSent);
       sendPacketVars.player->remove_player_event = 1;
       return totalSent;
     }
@@ -338,11 +334,54 @@ void sendMainByte(uint8_t byte)
   }
   sendPacketVars.buffer[sendPacketVars.bufferindex++] = byte;
 }
+static void sendQueueData(const uint8_t *data, size_t len)
+{
+  if (len == 0)
+  {
+    return;
+  }
+  if (sendPacketVars.player == NULL)
+  {
+    return;
+  }
+  out_packet_t *pkt = U_malloc(sizeof(out_packet_t));
+  if (pkt == NULL)
+  {
+    printl(LOG_ERROR, "Memory allocation failed packet queue!\n");
+    sendPacketVars.player->remove_player_event = 1;
+    return;
+  }
+  pkt->data = U_malloc(len);
+  if (pkt->data == NULL)
+  {
+    printl(LOG_ERROR, "Memory allocation failed packet data!\n");
+    U_free(pkt);
+    sendPacketVars.player->remove_player_event = 1;
+    return;
+  }
+  memcpy(pkt->data, data, len);
+  pkt->len = len;
+  pkt->sent = 0;
+  pkt->next = NULL;
+  if (sendPacketVars.player->out_tail)
+  {
+    sendPacketVars.player->out_tail->next = pkt;
+  }
+  else
+  {
+    sendPacketVars.player->out_head = pkt;
+  }
+  sendPacketVars.player->out_tail = pkt;
+}
 void sendDispatch()
 {
   // send the data
   if (sendPacketVars.bufferindex != 0)
   {
+    if (sendPacketVars.player->out_head != NULL)
+    {
+      sendFlush(sendPacketVars.player);
+    }
 #ifdef ONLINE_MODE
     if (sendPacketVars.player->encryption_recv_event)
     {
@@ -354,7 +393,72 @@ void sendDispatch()
       }
     }
 #endif /*ONLINE_MODE*/
-    sendData(sendPacketVars.buffer, sendPacketVars.bufferindex);
+    if (sendPacketVars.player->out_head != NULL)
+    {
+      sendQueueData(sendPacketVars.buffer, sendPacketVars.bufferindex);
+      sendPacketVars.bufferindex = 0;
+      return;
+    }
+    int blocked = 0;
+    size_t sent = sendData(sendPacketVars.buffer, sendPacketVars.bufferindex, &blocked);
+    if (blocked && sent < sendPacketVars.bufferindex)
+    {
+      sendQueueData(sendPacketVars.buffer + sent, sendPacketVars.bufferindex - sent);
+    }
+    sendPacketVars.bufferindex = 0;
+  }
+}
+void sendFlush(player_t *player)
+{
+  if (player == NULL)
+  {
+    return;
+  }
+  while (player->out_head)
+  {
+    out_packet_t *pkt = player->out_head;
+    if (pkt->sent >= pkt->len)
+    {
+      player->out_head = pkt->next;
+      if (player->out_head == NULL)
+      {
+        player->out_tail = NULL;
+      }
+      U_free(pkt->data);
+      U_free(pkt);
+      continue;
+    }
+    size_t remaining = pkt->len - pkt->sent;
+    size_t blockSize = remaining < MAX_SEND_FRAGMENT_SIZE ? remaining : MAX_SEND_FRAGMENT_SIZE;
+    ssize_t r = U_send(player->fd, (char *)pkt->data + pkt->sent, blockSize, MSG_NOSIGNAL);
+    if (r < 0)
+    {
+      if (errno == EAGAIN || errno == EWOULDBLOCK)
+      {
+        return;
+      }
+      printl(LOG_ERROR, "could not send (%d) code %ld (%p %ld)\n", player->fd, r, pkt->data, pkt->sent);
+      printl(LOG_ERROR, "errno: %s\n", strerror(errno));
+      player->remove_player_event = 1;
+      return;
+    }
+    if (r == 0)
+    {
+      printl(LOG_ERROR, "could not send (%d) code %ld (%p %ld)\n", player->fd, r, pkt->data, pkt->sent);
+      player->remove_player_event = 1;
+      return;
+    }
+    pkt->sent += (size_t)r;
+    if (pkt->sent == pkt->len)
+    {
+      player->out_head = pkt->next;
+      if (player->out_head == NULL)
+      {
+        player->out_tail = NULL;
+      }
+      U_free(pkt->data);
+      U_free(pkt);
+    }
   }
 }
 uint8_t sendAllowed() { return 1; }


### PR DESCRIPTION
# PR: Outbound send queue on EAGAIN

## Summary
Replace the single deferred packet buffer with a per-player outgoing queue so sends remain ordered and non-blocking. Packets are sent immediately when possible and queued only when the socket returns `EAGAIN`/`EWOULDBLOCK`.

## Key changes
- Added `out_packet_t` and per-player queue pointers in `include/UCraft/player.h`, removing the legacy `packet_dispatch_event` path.
- Updated `sendData()` to report blocking via an out param and return early on `EAGAIN`/`EWOULDBLOCK`.
- Implemented queueing and flushing in `src/socketio.c`, with cleanup of queued packets in `src/player.c`.
- Simplified the send loop in `src/UCraft.c` to `sendDispatch()` + `sendFlush()`.
- Moved `errno` include to `include/UCraft/wrapper_unix.h` and `include/UCraft/wrapper_win.h` after removing it from `include/UCraft/socketio.h`.

## Behavior
- If the socket is writable, `sendDispatch()` sends immediately and does not queue.
- If a send blocks, the unsent tail is queued and later flushed in order by `sendFlush()`.

## Note
AI assistance was used during the implementation (codex). Human intervention was involved though!
